### PR TITLE
Accessibility Suggestion

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -104,7 +104,7 @@ a[href]:not([class]):hover {
 	text-decoration: none;
 }
 :focus {
-	outline: none;
+	outline-color: transparent;
 }
 ::-moz-focus-inner {
 	border: 0;


### PR DESCRIPTION
Small accessibility defect in CSS when using "outline: none" was fixed. Made simple changes following best practices to prevent users with higher contrasts from experiencing bugs when using the tab key to select buttons, inputs, etc. Reference: https://www.youtube.com/shorts/4B_4WLpbyp8

Awesome site by the way! It gives me a super nostalgic feeling 😄 